### PR TITLE
ChipInput.vue:  rootElement.value can be undefined, use nullcheck

### DIFF
--- a/packages/codex/src/components/chip-input/ChipInput.vue
+++ b/packages/codex/src/components/chip-input/ChipInput.vue
@@ -306,7 +306,7 @@ export default defineComponent( {
 			// We don't do this in onInputBlur() because that is also called when the focus moves
 			// from the input to one of the chips.
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			if ( !rootElement.value!.contains( e.relatedTarget as Node ) ) {
+			if ( !rootElement.value?.contains( e.relatedTarget as Node ) ) {
 				addChip();
 			}
 		}


### PR DESCRIPTION
The rootElement.value is assumed to always exist, leading to a runtime error when it is undefined, particularly when navigating between views (using popstate + autofocus). The fix involves adding a null check for rootElement.value to prevent the error during the focusOut event after unmounting.

Reproduction: https://n2ts7j.csb.app/