### PR TITLE
Update radio.md - say to use role="radiogroup" not role="group"

### DIFF
--- a/packages/codex-docs/component-demos/radio/radio.md
+++ b/packages/codex-docs/component-demos/radio/radio.md
@@ -613,7 +613,7 @@ Always include one of these two features for accessible grouping:
   `<legend>` element with the group label. This method is demonstrated below and requires some
   style resets on `<fieldset>` and `<legend>`. You can use the CSS-only [Field](./field.md#css-only-version)
   and [Label](./label.md#css-only-version) components to reset browser styles of these elements.
-2. If using the Radio group outside of a field, wrap the group in a `<div>` with `role="group"`
+2. If using the Radio group outside of a field, wrap the group in a `<div>` with `role="radiogroup"`
   and `aria-labelledby` set to the ID of the group label. See an example of this
   [above](#radio-group).
 


### PR DESCRIPTION
The text says role="group" but the example does role="radiogroup". Looking at the aria docs, it sounds like radiogroup is more correct.