### PR TITLE
Remove legacy min-width and min-height from icon mixins (T401458)

### DIFF
--- a/packages/codex/src/themes/mixins/public/css-icon.less
+++ b/packages/codex/src/themes/mixins/public/css-icon.less
@@ -80,8 +80,6 @@
 .cdx-mixin-css-icon-size( @param-size-icon: @size-icon-medium ) {
 	.get-calculated-min-size-icon( @param-size-icon );
 	// Set the default icon size.
-	min-width: @calculated-min-size-icon;
-	min-height: @calculated-min-size-icon;
 	// Scale width/height of the span with font size.
 	width: @param-size-icon;
 	height: @param-size-icon;


### PR DESCRIPTION
This removes the min-width and min-height declarations from the icon size mixin in codex.

Bug: T401458