### PR TITLE
useFloatingMenu: Add option to allow menu to expand beyond the trigger

### DIFF
--- a/packages/codex-docs/docs/components/types-and-constants.md
+++ b/packages/codex-docs/docs/components/types-and-constants.md
@@ -111,6 +111,8 @@ The `Placement` and `OffsetOptions` types come from the 3rd-party
 ```ts
 interface FloatingMenuOptions {
 	useAvailableWidth?: boolean,
+	/* Default value: true */
+	matchTriggerWidth?: boolean, 
 	placement?: Placement,
 	offset?: OffsetOptions
 }

--- a/packages/codex/src/composables/useFloatingMenu.ts
+++ b/packages/codex/src/composables/useFloatingMenu.ts
@@ -54,12 +54,25 @@ export default function useFloatingMenu(
 			// of the menu and the bottom edge of the viewport / scrollable container.
 			padding: clipPadding,
 			apply( { rects, elements, availableHeight, availableWidth } ) {
-				Object.assign( elements.floating.style, {
-					// Optionally use all available width
-					// Else, set the width of the menu to match the width of the triggering element.
+				
+				// Determine Width Logic
+				let calculatedWidth = '';
+				
+				if ( opt?.useAvailableWidth ) {
+					// 1. Use all available width (viewport width)
+					calculatedWidth = `${ availableWidth }px`;
+				} else if ( opt?.matchTriggerWidth !== false ) {
+					// 2. Default: Match the width of the triggering element.
 					// This is needed in Dialogs, when the menu's position is set relative to
 					// the dialog, not the triggering element.
-					width: `${ opt?.useAvailableWidth ? availableWidth : rects.reference.width }px`,
+					// Check !== false to maintain backward compatibility (defaults to true)
+					calculatedWidth = `${ rects.reference.width }px`;
+				} 
+				// 3. If matchTriggerWidth is explicitly false, calculatedWidth stays ''
+				// allowing intrinsic sizing via CSS.
+
+				Object.assign( elements.floating.style, {
+					width: calculatedWidth,
 					// Set the max-height to the available height, to prevent the menu from
 					// extending past the edge of the viewport or scrollable container. But don't
 					// allow the menu to be shrunk to less than 128px; this is necessary to make

--- a/packages/codex/src/types.ts
+++ b/packages/codex/src/types.ts
@@ -183,6 +183,7 @@ export interface MenuConfig {
 /** @public */
 export interface FloatingMenuOptions {
 	useAvailableWidth?: boolean,
+	matchTriggerWidth?: boolean,
 	placement?: Placement,
 	offset?: OffsetOptions
 }


### PR DESCRIPTION
The default with is still set to matching the width of the trigger. This change is needed for the ULS rewrite that we are working on.